### PR TITLE
Complex hydratation from sql response with One to Many rel

### DIFF
--- a/fhirpipe/load/sql.py
+++ b/fhirpipe/load/sql.py
@@ -108,10 +108,8 @@ def run(query, connection: str = None):
         for el in row:
             if el is None:
                 new_row.append("")
-            elif isinstance(el, datetime.datetime):
+            else:  # Force conversion to str if not already (ex: datetime, int, etc)
                 new_row.append(str(el))
-            else:
-                new_row.append(el)
         rows[i] = new_row
     return rows
 

--- a/fhirpipe/parse/fhir.py
+++ b/fhirpipe/parse/fhir.py
@@ -80,12 +80,19 @@ def dfs_create_fhir_object(fhir_obj, fhir_spec, row):
             for fhir_spec_attr in fhir_spec["attributes"]:
                 if len(row) > 0 and isinstance(row[0], list):
                     join_rows = row.pop(0)
-                    for join_row in join_rows:
+                    join_rows_remaining = []
+                    for i, join_row in enumerate(join_rows):
                         fhir_obj_list_el = dict()
                         dfs_create_fhir_object(
-                            fhir_obj_list_el, fhir_spec_attr, list(join_row)
+                            fhir_obj_list_el, fhir_spec_attr, join_row
                         )
                         fhir_obj_list.append(fhir_obj_list_el)
+                        # Not everything has been consumed: we need to keep what's remaining
+                        if len(join_row) > 0:
+                            join_rows_remaining.append(join_row)
+                    # If there are remaining elements, we put them back
+                    if len(join_rows_remaining) > 0:
+                        row.insert(0, join_rows_remaining)
                 else:
                     fhir_obj_list_el = dict()
                     dfs_create_fhir_object(fhir_obj_list_el, fhir_spec_attr, row)


### PR DESCRIPTION
Fix the hydrating of distinct attributes with the same one to many relation.

We want to make sure that a One to Manys relations in several attributes can reference the same table and not interfere between them.