### PR TITLE
Add handling of FHIR references

### DIFF
--- a/fhirpipe/config_demo.yml
+++ b/fhirpipe/config_demo.yml
@@ -9,18 +9,19 @@ sql:
             database: "mimic"
             user: "mimicuser"
             password: "mimicuser"
+    fhirbase:
+        lib: 'psycopg2'
+        args: []
+        kwargs:
+            host: "localhost"
+            port: 5433
+            database: "fhirbase"
+            user: "postgres"
+            password: "postgres"
     oracle:
         lib: 'cx_Oracle'
         args: ['user/password@database']
         kwargs: {}
-
-
-fhirbase:
-    host: "localhost"
-    port: 5433
-    database: "fhirbase"
-    user: "postgres"
-    password: "postgres"
 
 graphql:
     server: 'https://graphql.pyrog.staging.arkhn.org/'

--- a/fhirpipe/console/run.py
+++ b/fhirpipe/console/run.py
@@ -6,7 +6,7 @@ import argparse
 import fhirpipe
 
 # TODO fetch names somewhere
-LIST_RESOURCES = ["Patient", "Practitioner"]
+LIST_RESOURCES = ["Encounter", "MedicationRequest", "Patient", "Practitioner", "Procedure"]
 
 
 def parse_args():

--- a/fhirpipe/console/run.py
+++ b/fhirpipe/console/run.py
@@ -94,7 +94,7 @@ def run():
     # Build a fhir object for each resource instance
     fhir_objects = []
     for i, row in enumerate(rows):
-        if i % 3000 == 0:
+        if i % 1000 == 0:
             progression = round(i / len(rows) * 100, 2)
             print("Progress... {} %".format(progression))
         row = list(row)
@@ -105,6 +105,7 @@ def run():
         # print(json.dumps(tree, indent=2, ensure_ascii=False))
 
     # Save instances in fhirbase
+    print("Saving in fhirbase...")
     fhirpipe.load.sql.save_in_fhirbase(fhir_objects)
 
     print(round((time.time() - start_time), 2), "seconds")
@@ -168,6 +169,7 @@ def batch_run():
             fhir_objects.append(fhir_object)
 
         # Save instances in fhirbase
+        print("Saving in fhirbase...")
         fhirpipe.load.sql.save_in_fhirbase(fhir_objects)
 
         # Log offset to restart in case of a crash

--- a/fhirpipe/load/sql.py
+++ b/fhirpipe/load/sql.py
@@ -10,7 +10,9 @@ from fhirpipe.config import Config
 def save_in_fhirbase(instances):
     """
     Save instances of FHIR resources in the fhirbase
-    :param instances: list of instances
+
+    args:
+        instances (list): list of instances
     """
     config = Config("sql").fhirbase.kwargs
     with psycopg2.connect(
@@ -26,8 +28,13 @@ def get_connection(connection_type: str = None):
     Return a sql connexion depending on the configuration provided in config.yml
     (see root of the project)
     Note: should be used in a context environment (with get_connection(c) as ...)
-    :param connection_type: a string like "postgre", "oracle". See your config file
-    :return: a sql connexion
+
+    args:
+        connection_type (str): a string like "postgre", "oracle". See your config
+            file for available values
+
+    return:
+        a sql connexion
     """
     sql_config = Config("sql").to_dict()
     if connection_type is None:
@@ -49,12 +56,16 @@ def get_connection(connection_type: str = None):
 def batch_run(query, batch_size, offset=0, connection=None):
     """
     Run a query batch per batch, when the query is too big
-    :param query: the query to batch
-    :param batch_size: the size of the batch
-    :param offset: initial offset (used when restarting a job which stopped
-    in the middle)
-    :param connection: a connection if any already active (to avoid opening too many)
-    :return: an iterator which computes and returns the results batch per batch
+
+    args:
+        query (str): the query to batch
+        batch_size (int): the size of the batch
+        offset (int): initial offset (used when restarting a job which stopped
+            in the middle)
+        connection (str): the connection type / database to use
+
+    return:
+        an iterator which computes and returns the results batch per batch
     """
     call_next_batch = True
     batch_idx = 0
@@ -92,8 +103,14 @@ def batch_run(query, batch_size, offset=0, connection=None):
 
 def run(query, connection: str = None):
     """
-    Run a sql query after opening a sql connexion
-    :param connection: type of connection: "postgre", "oracle" (see config.yml)
+    Run a sql query after opening a sql connection
+
+    args:
+        query (str): a sql query to run
+        connection (str): the connection type / database to use
+
+    return:
+        the result of the sql query run on the specified connection
     """
     with get_connection(connection) as connection:
         with connection.cursor() as cursor:
@@ -118,6 +135,7 @@ def apply_joins(rows, squash_rule, parent_cols=tuple()):
     """
     Apply the OneToMany joins to have a single result with a list in it from
     a list of "flat" results.
+
     args:
         rows (list<str>): all the results returned from a sql query
         squash_rule (tuple<list>): which columns should serve as identifier to merge


### PR DESCRIPTION
We need provided identifiers in references (like the id of some patient in the MIMIC database) to be replaced with FHIR ids of the associated FHIR objects if it exists.