### PR TITLE
Feature/clustered run pipe

### DIFF
--- a/fhirpipe/console/submit.py
+++ b/fhirpipe/console/submit.py
@@ -1,0 +1,13 @@
+from fhirpipe.console import WELCOME_MSG
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import expr, col, count, desc
+
+import fhirpipe
+
+spark = SparkSession \
+        .builder \
+        .appName("Bundle FHIR resources to hive tables") \
+        .enableHiveSupport() \
+        .getOrCreate()
+
+df = fhirpipe.load.spark_sql.load_table(spark, "MIMICIII.PATIENTS")

--- a/fhirpipe/load/spark_sql.py
+++ b/fhirpipe/load/spark_sql.py
@@ -1,0 +1,25 @@
+from fhirpipe.config import Config
+from pyspark.sql import SparkSession
+
+
+def load_sql_table(spark, config, table):
+    """
+    Returns a dataframe based on a table available in the connected database from config.
+    args:
+        spark (SparkSession): the spark context.
+        table (str): the table name written as such: `schema_name.table_name` to be turned into a Spark dataframe
+
+    """
+
+
+    sql_config = Config("spark_slq").to_dict()
+    if connection_type is None:
+        connection_type = sql_config["default"]
+    connection = sql_config[connection_type]
+
+    return spark.format("jdbc") \
+        .option("url", "jdbc:{}:{}".format(connection["driver"], connection["database"])) \
+        .option("dbtable", table) \
+        .option('user', connection["user"]) \
+        .option("password", connection["password"]) \
+        .load()


### PR DESCRIPTION
# Clustered-run fhir-pipe

## Summary
In this branch, the dev work will consist in making `fhir-pipe` run on a cluster running Hadoop, Spark and Hive.

In other word, we’ll try to run 
`fhirpipe-run —project=someProject` as `spark-submit fhirpie-run -project someProject`

## Motivation
For now, the pipe is functional in a single machine environment and raw data is processed through python data model. It is stored in a classic RDBMS such as Fhirbase on PostgreSQL

Since the end goal is to run the pipe on massive amount of data generated by healthcare structures, the ETL should be able to run on a clustered environment.

### Current architecture of the repo
The repo is currently made of 5 packages : 
* `fhipipe/parse` takes care of parsing file from  Pyrog or .yml files and generates appropriates SQL queries, then parses the results of those queries to put them in proper FHIR resources.
* `fhirpipe/load` turns queries and rules created with  `parse`  and loads them from a client’s database to the FHIR store (currently FHIRbase)
* `fhirpipe/console` handles the command line arguments and options to launch the pipe.
* `fhirpipe/scripts` stores scripts associated with data cleaning and processing.
* `fhirpipe/write` contains helper functions to log the  state of the running pipe in files.

## Discussion
### Rewrite `parse`
The module that manipulates raw data is essentially `fhir.py` and  needs a rewrite.

### Rewriting `load`
The essential rewrite of `fhirpipe/load` lies in the `sql.py` module, that also manipulates raw data.

### Rewriting `console`
The command line commands that `console` makes available such as `fhirpipe-run` will be stripped, on the other hand, argument parsing will be kept.

### Rewriting `scripts`
Scripts will now need to take into account that data aren’t processed through the python data model but Spark RDD’s.

### Checklist
- [x] First commit with drafts of `locd/spark_sql.py` and `console/submit.py`
- [x] Create a reproductible test environment with a cluster configuration on CI
- [ ] …

_To be continued…_


