### PR TITLE
Mock pyrog mapping, progress bar and fetch available resources from pyrog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 data/*
 .idea/*
+cx_Oracle-doc/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@ RUN apt-get update \
 # Set the working directory to /app
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-COPY ./fhirpipe /app/fhirpipe
-COPY ./test /app/test
+# Install any needed packages specified in requirements.txt
 COPY requirements.txt /app
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY ./test /app/test
 COPY config_docker.yml /app/config.yml
 COPY setup.py /app
 COPY README.md /app
-
-# Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+COPY ./fhirpipe /app/fhirpipe
 
 RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY requirements.txt /app
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 # Copy the current directory contents into the container at /app
-COPY ./test /app/test
 COPY config_docker.yml /app/config.yml
 COPY setup.py /app
 COPY README.md /app

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -87,7 +87,7 @@ And to run to whole pipe
 fhirpipe-run --project=Mimic
 ```
 
-> You can use the option `--use-graphql-file=True` to fetch the mapping rules directly from a static file instead of the [pyrog](https://github.com/arkhn/pyrog) api. In this case, you need to provide a token in `config.yml` for the graphql access. Contact us at [contact@arkhn.org](mailto:contact@arkhn.org?subject=Ask%20access%20to%20GraphQL%20api) to get one.
+> You can use the option `--mock-pyrog-mapping=path/to/response.json` to fetch the mapping rules directly from a static file instead of the [pyrog](https://github.com/arkhn/pyrog) api. In this case, you need to provide a token in `config.yml` for the graphql access. Contact us at [contact@arkhn.org](mailto:contact@arkhn.org?subject=Ask%20access%20to%20GraphQL%20api) to get one.
 
 You can also run the pipe on a single FHIR resource:
 
@@ -202,8 +202,8 @@ Let's now run locally the pipeline!
 You are all set! Run:
 
 ```
-fhirpipe-run --project=Mimic --resource=Patient --main-table=Patients --use-graphql-file=True
+fhirpipe-run --project=Mimic --resource=Patient --main-table=Patients --mock-pyrog-mapping=test/integration/fixtures/graphql_mimic.json
 ```
 
-Remove `--use-graphql-file=True` to get the latest mapping rules from the pyrog api.
+Remove `--mock-pyrog-mapping` to get the latest mapping rules from the pyrog api.
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ install:
 	)
 
 # == build ====================================================================
-build:
-	docker build --no-cache -t $(DOCKER_IMAGE):$(DOCKER_TAG) -f Dockerfile .
+build: Dockerfile
+	docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) -f Dockerfile .
 
 # == publish ====================================================================
 publish:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: arkhn-pipe-mimic
     image: arkhn/pipe-mimic:latest
     command: tail -F anything
+    volumes:
+      - ./test:/app/test
     depends_on:
       - mimic-db
       - fhirbase

--- a/docker/2_postgres_load_data.sql
+++ b/docker/2_postgres_load_data.sql
@@ -70,7 +70,7 @@
 --  Load Data for Table D_CPT
 --------------------------------------------------------
 
-\copy D_CPT from 'd_pt.csv' delimiter ',' csv header NULL ''
+\copy D_CPT from 'd_cpt.csv' delimiter ',' csv header NULL ''
 
 --------------------------------------------------------
 --  Load Data for Table D_ICD_DIAGNOSES
@@ -124,7 +124,7 @@
 --  Load Data for Table MICROBIOLOGYEVENTS
 --------------------------------------------------------
 
-\copy MICROBIOLOGYEVENTS from 'microbilogyevents.csv' delimiter ',' csv header NULL ''
+\copy MICROBIOLOGYEVENTS from 'microbiologyevents.csv' delimiter ',' csv header NULL ''
 
 --------------------------------------------------------
 --  Load Data for Table NOTEEVENTS
@@ -154,7 +154,7 @@
 --  Load Data for Table PROCEDUREEVENTS_MV
 --------------------------------------------------------
 
-\copy PROCEDUREEVENTS_MV from 'procedureevents.csv' delimiter ',' csv header NULL ''
+\copy PROCEDUREEVENTS_MV from 'procedureevents_mv.csv' delimiter ',' csv header NULL ''
 
 --------------------------------------------------------
 --  Load Data for Table PROCEDURES_ICD

--- a/fhirpipe/console/__init__.py
+++ b/fhirpipe/console/__init__.py
@@ -1,4 +1,3 @@
-from .parse_args import LIST_RESOURCES
 from .parse_args import parse_args
 
 WELCOME_MSG = """

--- a/fhirpipe/console/parse_args.py
+++ b/fhirpipe/console/parse_args.py
@@ -46,9 +46,9 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--use-graphql-file",
-        type=bool,
-        default=False,
+        "--mock-pyrog-mapping",
+        type=str,
+        default=None,
         help="Use graphql file response instead of the API",
         required=False,
     )

--- a/fhirpipe/console/parse_args.py
+++ b/fhirpipe/console/parse_args.py
@@ -1,16 +1,6 @@
 import argparse
 
 
-# TODO fetch names somewhere
-LIST_RESOURCES = [
-    "Patient",
-    "Practitioner",
-    "Encounter",
-    "MedicationRequest",
-    "Procedure",
-]
-
-
 def parse_args():
     """
     Read all the arguments which should describe the run task
@@ -37,7 +27,6 @@ def parse_args():
         "--resource",
         type=str,
         default="Patient",
-        choices=set(LIST_RESOURCES),
         help="Resource type to process (default: Patient)",
     )
 

--- a/fhirpipe/console/run.py
+++ b/fhirpipe/console/run.py
@@ -31,9 +31,11 @@ def run():
     set_global_config(Config(path=args.config))
 
     # Get all resources available in the pyrog mapping for a given source
-    list_resources = [r["name"] for r in get_available_resources(args.project)]
-    n = len(list_resources)
+    list_resources = [r["name"] for r in get_available_resources(
+        args.project,
+        from_file=args.mock_pyrog_mapping)]
 
+    n = len(list_resources)
     for i, resource in enumerate(list_resources):
         print(f"Integrating FHIR resource {resource} ({i+1}/{n})")
 
@@ -46,7 +48,7 @@ def run():
                 self.resource = resource
                 self.main_table = main_table
                 self.project = args.project
-                self.use_graphql_file = args.use_graphql_file
+                self.mock_pyrog_mapping = args.mock_pyrog_mapping
 
         run_resource(args=Parser())
 

--- a/fhirpipe/console/run.py
+++ b/fhirpipe/console/run.py
@@ -5,12 +5,9 @@ import argparse
 
 from fhirpipe import set_global_config
 from fhirpipe.config import Config
-from fhirpipe.console import parse_args
-from fhirpipe.console import LIST_RESOURCES
-
-from fhirpipe.console import WELCOME_MSG
-
+from fhirpipe.console import parse_args, WELCOME_MSG
 from fhirpipe.console.run_resource import run_resource
+from fhirpipe.load.graphql import get_available_resources
 
 
 def run():
@@ -33,7 +30,8 @@ def run():
     # Define global config
     set_global_config(Config(path=args.config))
 
-    list_resources = LIST_RESOURCES
+    # Get all resources available in the pyrog mapping for a given source
+    list_resources = [r["name"] for r in get_available_resources(args.project)]
     n = len(list_resources)
 
     for i, resource in enumerate(list_resources):

--- a/fhirpipe/console/run.py
+++ b/fhirpipe/console/run.py
@@ -25,7 +25,7 @@ def run():
     # Parse arguments
     args = parse_args()
 
-    print(WELCOME_MSG)
+    print(WELCOME_MSG, flush=True)
 
     # Launch timer
     start_time = time.time()

--- a/fhirpipe/console/run_resource.py
+++ b/fhirpipe/console/run_resource.py
@@ -34,7 +34,6 @@ def run_resource(args=None):
     resource_structure = fhirpipe.load.graphql.get_fhir_resource(
         args.project, args.resource, from_file=path
     )
-    print(2, flush=True)
 
     # Get main table
     main_table = fhirpipe.parse.fhir.get_identifier_table(resource_structure)
@@ -58,13 +57,14 @@ def run_resource(args=None):
 
     # Build a fhir object for each resource instance
     fhir_objects = []
-    for i, row in enumerate(tqdm(rows)):
+    rows = tqdm(rows)
+    for i, row in enumerate(rows):
         row = list(row)
         fhir_object = fhirpipe.parse.fhir.create_fhir_object(
             row, args.resource, resource_structure
         )
         fhir_objects.append(fhir_object)
-        # print(json.dumps(tree, indent=2, ensure_ascii=False))
+        rows.refresh()
 
     # Save instances in fhirbase
     print("Saving in fhirbase...", flush=True)
@@ -122,15 +122,14 @@ def batch_run_resource():
 
         # Hydrate FHIR objects
         fhir_objects = []
+        rows = tqdm(rows)
         for i, row in enumerate(rows):
-            if i % 1000 == 0:
-                progression = round(i / len(rows) * 100, 2)
-                print("batch {} %".format(progression))
             row = list(row)
             fhir_object = fhirpipe.parse.fhir.create_fhir_object(
                 row, resource, resource_structure
             )
             fhir_objects.append(fhir_object)
+            rows.refresh()
 
         # Save instances in fhirbase
         print("Saving in fhirbase...")

--- a/fhirpipe/console/run_resource.py
+++ b/fhirpipe/console/run_resource.py
@@ -25,25 +25,18 @@ def run_resource(args=None):
     # Launch timer
     start_time = time.time()
 
-    print(1, flush=True)
-    if args.use_graphql_file:
-        path = "../../test/integration/fixtures/graphql_mimic.json"
-    else:
-        path = None
     # Load mapping rules
     resource_structure = fhirpipe.load.graphql.get_fhir_resource(
-        args.project, args.resource, from_file=path
+        args.project, args.resource, from_file=args.mock_pyrog_mapping
     )
 
     # Get main table
     main_table = fhirpipe.parse.fhir.get_identifier_table(resource_structure)
-    print(3, flush=True)
 
     # Build the sql query
     sql_query, squash_rules, graph = fhirpipe.parse.sql.build_sql_query(
         args.project, resource_structure, info=main_table
     )
-    print(4, flush=True)
 
     # Run it
     print("Launching query...", flush=True)
@@ -53,7 +46,6 @@ def run_resource(args=None):
 
     # Apply join rule to merge some lines from the same resource
     rows = fhirpipe.load.sql.apply_joins(rows, squash_rules)
-    print(5, flush=True)
 
     # Build a fhir object for each resource instance
     fhir_objects = []
@@ -95,8 +87,10 @@ def batch_run_resource():
     batch_size = args.batch_size
 
     # Load data
-    resource_structure = fhirpipe.graphql.get_fhir_resource(project,
-                                                            resource)
+    resource_structure = fhirpipe.graphql.\
+        get_fhir_resource(project,
+                          resource,
+                          from_file=args.mock_pyrog_mapping)
 
     # Build the sql query
     sql_query, squash_rules, graph = fhirpipe.parse.sql.build_sql_query(

--- a/fhirpipe/load/graphql.py
+++ b/fhirpipe/load/graphql.py
@@ -128,7 +128,6 @@ def run_graphql_query(graphql_query, variables=None):
         fhirpipe.global_config.graphql.server, headers=get_headers(), json={
             "query": graphql_query, "variables": variables}
     )
-    print(request.json())
     if request.status_code == 200:
         return request.json()
     else:

--- a/fhirpipe/load/graphql.py
+++ b/fhirpipe/load/graphql.py
@@ -171,25 +171,16 @@ def get_fhir_resource(source_name, resource_name, from_file=None):
             f"Resource {resource_name} not found in the graphql json resource"
         )
     else:
-        # Get Source id from Source name
-        source = run_graphql_query(
-            source_info_query, variables={"sourceName": source_name}
-        )
-        source_id = source["data"]["sourceInfo"]["id"]
-
-        # Check that Resource exists for given Source
-        available_resources = run_graphql_query(
-            available_resources_query, variables={"sourceId": source_id}
-        )
+        available_resources = get_available_resources(source_name)
         assert resource_name in list(
-            map(lambda x: x["name"], available_resources["data"]["availableResources"])
+            map(lambda x: x["name"], available_resources)
         ), f"Resource {resource_name} doesn't exist for Source {source_name}"
 
         # Deduce Resource id from Resource name
         resource_id = list(
             filter(
                 lambda x: x["name"] == resource_name,
-                available_resources["data"]["availableResources"],
+                available_resources,
             )
         )[0]["id"]
 
@@ -199,3 +190,17 @@ def get_fhir_resource(source_name, resource_name, from_file=None):
         )
 
         return resource["data"]["resource"]
+
+
+def get_available_resources(source_name):
+    # Get Source id from Source name
+    source = run_graphql_query(
+        source_info_query, variables={"sourceName": source_name}
+    )
+    source_id = source["data"]["sourceInfo"]["id"]
+
+    # Check that Resource exists for given Source
+    available_resources = run_graphql_query(
+        available_resources_query, variables={"sourceId": source_id}
+    )
+    return available_resources["data"]["availableResources"]

--- a/fhirpipe/load/graphql.py
+++ b/fhirpipe/load/graphql.py
@@ -192,6 +192,16 @@ def get_fhir_resource(source_name, resource_name, from_file=None):
 
 
 def get_available_resources(source_name, from_file=None):
+    """
+    Get all available resources from a pyrog mapping.
+    The mapping may either come from a static file or from
+    a pyrog graphql API.
+
+    Args:
+        source_name: name of the project (eg: Mimic)
+        from_file (optional): path to the static file to mock
+                              the pyrog API response.
+    """
     if from_file:
         path = from_file
         if not os.path.isabs(path):

--- a/fhirpipe/load/graphql.py
+++ b/fhirpipe/load/graphql.py
@@ -151,11 +151,10 @@ def get_fhir_resource(source_name, resource_name, from_file=None):
 
     if from_file is not None:
         path = from_file
-        real_path = "/".join(
-            os.path.abspath(__file__).split("/")[:-1] + path.split("/")
-        )
+        if not os.path.isabs(path):
+            path = os.path.join(os.getcwd(), path)
 
-        with open(real_path) as json_file:
+        with open(path) as json_file:
             resources = json.load(json_file)
         source_json = resources["data"]["database"]
 
@@ -192,15 +191,27 @@ def get_fhir_resource(source_name, resource_name, from_file=None):
         return resource["data"]["resource"]
 
 
-def get_available_resources(source_name):
-    # Get Source id from Source name
-    source = run_graphql_query(
-        source_info_query, variables={"sourceName": source_name}
-    )
-    source_id = source["data"]["sourceInfo"]["id"]
+def get_available_resources(source_name, from_file=None):
+    if from_file:
+        path = from_file
+        if not os.path.isabs(path):
+            path = os.path.join(os.getcwd(), path)
 
-    # Check that Resource exists for given Source
-    available_resources = run_graphql_query(
-        available_resources_query, variables={"sourceId": source_id}
-    )
-    return available_resources["data"]["availableResources"]
+        with open(path) as json_file:
+            resources = json.load(json_file)
+        source_json = resources["data"]["database"]
+
+        return source_json["resources"]
+
+    else:
+        # Get Source id from Source name
+        source = run_graphql_query(
+            source_info_query, variables={"sourceName": source_name}
+        )
+        source_id = source["data"]["sourceInfo"]["id"]
+
+        # Check that Resource exists for given Source
+        available_resources = run_graphql_query(
+            available_resources_query, variables={"sourceId": source_id}
+        )
+        return available_resources["data"]["availableResources"]

--- a/fhirpipe/load/sql.py
+++ b/fhirpipe/load/sql.py
@@ -3,6 +3,7 @@ import psycopg2
 import cx_Oracle
 import logging
 import fhirbase
+from tqdm import tqdm
 
 import fhirpipe
 
@@ -22,7 +23,7 @@ def save_in_fhirbase(instances):
         password=fhirpipe.global_config.sql.fhirbase.kwargs.password
     ) as connection:
         fb = fhirbase.FHIRBase(connection)
-        for instance in instances:
+        for instance in tqdm(instances):
             fb.create(instance)
 
 

--- a/fhirpipe/load/sql.py
+++ b/fhirpipe/load/sql.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 import fhirpipe
 
 
-def save_in_fhirbase(instance):
+def save_in_fhirbase(instances):
     """
     Save instances of FHIR resources in the fhirbase
 
@@ -94,7 +94,8 @@ def batch_run(query, batch_size, offset=0, connection=None):
     elif database_type == "postgre":
         offset_batch_size_instruction = " OFFSET {} LIMIT {}"
     else:
-        raise RuntimeError(f"{database_type} is not a supported database type.")
+        raise RuntimeError(
+            f"{database_type} is not a supported database type.")
 
     while call_next_batch:
         batch_query = query + offset_batch_size_instruction.format(offset,
@@ -132,7 +133,8 @@ def run(query, connection: str = None):
         for el in row:
             if el is None:
                 new_row.append("")
-            else:  # Force conversion to str if not already (ex: datetime, int, etc)
+            # Force conversion to str if not already (ex: datetime, int, etc)
+            else:
                 new_row.append(str(el))
         rows[i] = new_row
     return rows

--- a/fhirpipe/load/sql.py
+++ b/fhirpipe/load/sql.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 import fhirpipe
 
 
-def save_in_fhirbase(instances):
+def save_in_fhirbase(instance):
     """
     Save instances of FHIR resources in the fhirbase
 
@@ -23,8 +23,10 @@ def save_in_fhirbase(instances):
         password=fhirpipe.global_config.sql.fhirbase.kwargs.password
     ) as connection:
         fb = fhirbase.FHIRBase(connection)
-        for instance in tqdm(instances):
+        instances = tqdm(instances)
+        for instance in instances:
             fb.create(instance)
+            instances.refresh()
 
 
 def get_connection(connection_type: str = None):

--- a/fhirpipe/parse/fhir.py
+++ b/fhirpipe/parse/fhir.py
@@ -24,7 +24,8 @@ def create_fhir_object(row, resource, resource_structure):
         a dictionary with a the structure of a fhir object
     """
     # Identify the fhir object
-    fhir_object = {"id": int(random.random() * 10e10), "resourceType": resource}
+    fhir_object = {"id": int(random.random() * 10e10),
+                   "resourceType": resource}
 
     # The first node has a different structure so iterate outside the
     # dfs_create_fhir function
@@ -97,7 +98,8 @@ def dfs_create_fhir_object(fhir_obj, fhir_spec, row):
                         row.insert(0, join_rows_remaining)
                 else:
                     fhir_obj_list_el = dict()
-                    dfs_create_fhir_object(fhir_obj_list_el, fhir_spec_attr, row)
+                    dfs_create_fhir_object(
+                        fhir_obj_list_el, fhir_spec_attr, row)
                     fhir_obj_list.append(fhir_obj_list_el)
             fhir_obj[fhir_spec["name"]] = fhir_obj_list
         # 2. It's a profile: we don't keep this layer in the fhir object and put
@@ -109,7 +111,8 @@ def dfs_create_fhir_object(fhir_obj, fhir_spec, row):
         else:
             fhir_obj[fhir_spec["name"]] = dict()
             for fhir_spec_attr in fhir_spec["attributes"]:
-                dfs_create_fhir_object(fhir_obj[fhir_spec["name"]], fhir_spec_attr, row)
+                dfs_create_fhir_object(
+                    fhir_obj[fhir_spec["name"]], fhir_spec_attr, row)
 
             # If the object is a Reference, to we give it to bind_reference
             if fhir_spec["type"].startswith("Reference"):
@@ -172,7 +175,8 @@ def bind_reference(fhir_object, fhir_spec):
 
         # Collect all the resource_types which could be referenced
         try:
-            resource_types = re.search('\((.*)\)', fhir_spec["type"]).group(1).split('|')
+            resource_types = re.search(
+                '\((.*)\)', fhir_spec["type"]).group(1).split('|')
         except AttributeError:
             raise ReferenceError(
                 f"No FHIR Resource type provided for the reference {fhir_spec['name']}")
@@ -210,7 +214,8 @@ def get_identifier_table(resource_structure, extended_get=False):
 
     if len(targets) < 1:
         if extended_get:
-            raise AttributeError("There is no mapping rule for the identifier of this resource")
+            raise AttributeError(
+                "There is no mapping rule for the identifier of this resource")
         else:
             return get_identifier_table(resource_structure, extended_get=True)
     else:

--- a/fhirpipe/parse/fhir.py
+++ b/fhirpipe/parse/fhir.py
@@ -174,7 +174,8 @@ def bind_reference(fhir_object, fhir_spec):
         try:
             resource_types = re.search('\((.*)\)', fhir_spec["type"]).group(1).split('|')
         except AttributeError:
-            raise ReferenceError(f"No FHIR Resource type provided for the reference {fhir_spec['name']}")
+            raise ReferenceError(
+                f"No FHIR Resource type provided for the reference {fhir_spec['name']}")
 
         # Search for a fhir instance among the listed resources and exit when one is found
         fhir_uri = None
@@ -234,15 +235,10 @@ def search_for_input_columns(obj, targets):
         if 'inputColumns' in obj and len(obj['inputColumns']) > 0:
             input_cols = obj['inputColumns']
             for input_col in input_cols:
-                targets.append(input_col['table'])
+                if input_col['table']:
+                    targets.append(input_col['table'])
         elif 'attributes' in obj:
             search_for_input_columns(obj['attributes'], targets)
     elif isinstance(obj, list):
         for o in obj:
             search_for_input_columns(o, targets)
-
-
-
-
-
-

--- a/fhirpipe/parse/sql.py
+++ b/fhirpipe/parse/sql.py
@@ -222,7 +222,8 @@ def build_squash_rule(node, table_col_idx):
     unifying_col_idx = table_col_idx[node.name]
     for join_node in node.one_to_one:
         # print(node.name, "---", join_node.name)
-        join_cols, join_child_rules = build_squash_rule(join_node, table_col_idx)
+        join_cols, join_child_rules = build_squash_rule(
+            join_node, table_col_idx)
         unifying_col_idx += join_cols
         if len(join_child_rules) > 0:
             print("ERROR", join_child_rules, "not handled")

--- a/fhirpipe/parse/sql.py
+++ b/fhirpipe/parse/sql.py
@@ -45,7 +45,6 @@ def build_sql_query(project, resource, info=None):
         )
 
     table_name = get_table_name(info + ".*")
-    # table_name = get_table_name(info.upper() + ".*")
 
     # Get the info about the columns and joins to query
     cols, joins = dfs_find_sql_cols_joins(

--- a/fhirpipe/parse/sql.py
+++ b/fhirpipe/parse/sql.py
@@ -44,7 +44,8 @@ def build_sql_query(project, resource, info=None):
             Don't forget to provide the owner if it applies"
         )
 
-    table_name = get_table_name(info.upper() + ".*")
+    table_name = get_table_name(info + ".*")
+    # table_name = get_table_name(info.upper() + ".*")
 
     # Get the info about the columns and joins to query
     cols, joins = dfs_find_sql_cols_joins(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ psycopg2==2.8.3
 simplejson==3.16.0
 wincertstore==0.2
 PyYAML==5.1
+tqdm==4.36.1 
 fhirbase
 requests
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,6 @@ def read(fname):
 
 requirements = read("requirements.txt").split()
 
-data_files = [
-    'config.yml',
-    'test/integration/fixtures/graphql_mimic.json',
-    'test/integration/fixtures/graphql_mimic_patient.json'
-]
-
 setup(
     name='fhirpipe',
     version='0.1',
@@ -30,7 +24,6 @@ setup(
     license='Apache License 2.0',
     packages=find_packages(exclude=["docs", "examples", "dist"]),
     include_package_data=True,
-    data_files=[('', data_files)],
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=requirements,

--- a/test/integration/console/test_run.py
+++ b/test/integration/console/test_run.py
@@ -11,7 +11,7 @@ def test_adapted_run():
     resource = "Patient"
 
     # Load LOCAL mapping rules
-    path = "../../test/integration/fixtures/graphql_mimic_patient.json"
+    path = "test/integration/fixtures/graphql_mimic_patient.json"
     resource_structure = fhirpipe.load.graphql.get_fhir_resource(
         project, resource, from_file=path
     )

--- a/test/integration/loader/test_graphql.py
+++ b/test/integration/loader/test_graphql.py
@@ -2,11 +2,12 @@ import fhirpipe
 
 
 def test_get_fhir_resource():
-    path = "../../test/integration/fixtures/graphql_mimic_patient.json"
+    path = "test/integration/fixtures/graphql_mimic_patient.json"
     resource_structure = fhirpipe.load.graphql.get_fhir_resource(
         "Mimic", "Patient", from_file=path
     )
 
     assert any(
-        attr["name"] == "identifier" for attr in resource_structure["attributes"]
+        attr["name"] == "identifier"
+        for attr in resource_structure["attributes"]
     )


### PR DESCRIPTION
## Description

This PR includes several fixes and 3 "features" (among which 1 is a breaking change):

Fixes:
- retrieving the test mimic data from their website has been fixed
- the table name found in the pyrog mapping was always upper-cased, it caused an error in the case of mimic.
- lint issues

Features:
- [BREAKING] replace `--use-graphql-file=<bool>` by `--mock-pyrog-mapping=<str>` which allows for a greater flexibility (no more path to a fixture hard-coded in `run_resource`, yay!). This allowed me to remove the test fixtures from the docker image (we can now mount the required file into the container) as well as from the `setup.py`. The way to load files from the code is now more straightforward :
```python
  def somefunc(path):
        if not os.path.isabs(path): #check if the path is absolute or relative
            path = os.path.join(os.getcwd(), path) #if it is relatve (eg: '../test' then join it with the current directory --> the one from which the program is run)
        with open(path) as my_file:
            # do stuff
```
No more step is required to get things up-and-running and I updated the doc.
- add a progress bar during the "transform" part and the "load" part (using [tqdm](https://tqdm.github.io/docs/tqdm/)
- remove the constant list of resources to process, and instead fetch them from pyrog (or extract them from the `mock_pyrog_mapping` file if specified)

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective, if unittests are enabled
- [x] New and existing unit tests pass locally with my changes, if any

