### PR TITLE
Handle None leaves in create_fhir_object

### DIFF
--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -57,7 +57,7 @@ def build_fhir_leaf_attribute(structure, row, indices):
         return None
 
     # Unlist
-    if len(result) == 1:
+    if isinstance(result, list) and len(result) == 1:
         result = result[0]
 
     if isinstance(result, tuple):

--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -53,9 +53,6 @@ def build_fhir_leaf_attribute(structure, row, indices):
         result = [row[c] for c in cols_to_fetch[0]]
         result.extend(cols_to_fetch[1])
 
-    if result is None:
-        return None
-
     # Unlist
     if isinstance(result, list) and len(result) == 1:
         result = result[0]

--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -12,7 +12,7 @@ def create_resource(chunk, resource_structure):
         except Exception as e:
             # If cannot build the fhir object, a warning has been logged
             # and we try to generate the next one
-            logging.warning(e)
+            logging.error(f"create_fhir_object failed with: {e}")
             continue
     return res
 
@@ -52,6 +52,9 @@ def build_fhir_leaf_attribute(structure, row, indices):
     else:
         result = [row[c] for c in cols_to_fetch[0]]
         result.extend(cols_to_fetch[1])
+
+    if result is None:
+        return None
 
     # Unlist
     if len(result) == 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fhirstore==0.2.0
-cleaning-scripts==0.2.3
+cleaning-scripts==0.2.4
 cx_Oracle==7.1.2
 psycopg2==2.8.3
 tqdm==4.36.1 


### PR DESCRIPTION
- Bump merging scripts
- Handle none leaves in create_fhir_object (len(None)) does not work
