### PR TITLE
Reduce fhirstore bootstrap complexity

### DIFF
--- a/fhirpipe/cli/run.py
+++ b/fhirpipe/cli/run.py
@@ -106,7 +106,7 @@ def run():
 
             # Bootstrap for resource if needed
             if fhirType not in fhirstore.resources:
-                fhirstore.bootstrap(resource=fhirType, depth=4)
+                fhirstore.bootstrap(resource=fhirType, depth=3)
 
             if args.multiprocessing:
                 fhir_objects_chunks = pool.map(


### PR DESCRIPTION
When running on chimio, it raised an error when creating the collection ("request payload too large")