### PR TITLE
Enable a more granular resource selection with label

### DIFF
--- a/fhirpipe/cli/parse_args.py
+++ b/fhirpipe/cli/parse_args.py
@@ -12,6 +12,10 @@ def parse_args():
     )
 
     parser.add_argument(
+        "-s", "--sources", nargs="+", type=str, default=None, help="Names of sources to process",
+    )
+
+    parser.add_argument(
         "-r", "--resources", nargs="+", type=str, default=None, help="Resource types to process",
     )
 
@@ -33,10 +37,6 @@ def parse_args():
         type=str,
         default=None,
         help="Use graphql file response instead of the API",
-    )
-
-    parser.add_argument(
-        "-s", "--source", type=str, default="Mimic", help="Project to run (default: Mimic)",
     )
 
     parser.add_argument(

--- a/fhirpipe/cli/parse_args.py
+++ b/fhirpipe/cli/parse_args.py
@@ -12,7 +12,11 @@ def parse_args():
     )
 
     parser.add_argument(
-        "-r", "--resources", nargs="+", type=str, default=None, help="Resource type to process",
+        "-r", "--resources", nargs="+", type=str, default=None, help="Resource types to process",
+    )
+
+    parser.add_argument(
+        "-l", "--labels", nargs="+", type=str, default=None, help="Labels of resources to process",
     )
 
     parser.add_argument(

--- a/fhirpipe/cli/run.py
+++ b/fhirpipe/cli/run.py
@@ -48,7 +48,10 @@ def run():
 
     # Get the resources we want to process from the pyrog mapping for a given source
     resources = get_mapping(
-        from_file=args.mapping, source_name=args.source, selected_resources=args.resources,
+        from_file=args.mapping,
+        source_name=args.source,
+        selected_resources=args.resources,
+        selected_labels=args.labels,
     )
 
     fhirstore = get_fhirstore()

--- a/fhirpipe/cli/run.py
+++ b/fhirpipe/cli/run.py
@@ -49,7 +49,7 @@ def run():
     # Get the resources we want to process from the pyrog mapping for a given source
     resources = get_mapping(
         from_file=args.mapping,
-        source_name=args.source,
+        selected_sources=args.sources,
         selected_resources=args.resources,
         selected_labels=args.labels,
     )

--- a/fhirpipe/extract/graphql.py
+++ b/fhirpipe/extract/graphql.py
@@ -4,110 +4,122 @@ import fhirpipe
 
 
 def build_resources_query(selected_sources=None, selected_resources=None, selected_labels=None):
-    # NOTE the curly braces have to be doubled in f-strings
-    # NOTE The .replace("'", '"') is needed because the graphql needs to have
-    # strings delimited by double quotes
-    return f"""fragment entireColumn on Column {{
+    """ Builds a graphql query fetching all the resources needed.
+
+    Note that the .replace("'", '"') is needed because the graphql needs to have
+    strings delimited by double quotes.
+    """
+    source_filter = (
+        """source: {
+                name: { in: %s }
+            }"""
+        % selected_sources
+        if selected_sources
+        else ""
+    )
+    resource_filter = "fhirType: { in: %s }" % selected_resources if selected_resources else ""
+    label_filter = "label: { in: %s }" % selected_labels if selected_labels else ""
+
+    return (
+        """fragment entireColumn on Column {
     id
     owner
     table
     column
-    joins {{
+    joins {
         id
-        tables {{
+        tables {
             id
             owner
             table
             column
-        }}
-    }}
-}}
+        }
+    }
+}
 
-fragment entireInput on Input {{
+fragment entireInput on Input {
     id
-    sqlValue {{
+    sqlValue {
         ...entireColumn
-    }}
+    }
     script
     staticValue
-}}
+}
 
-fragment a on Attribute {{
+fragment a on Attribute {
     id
     name
     fhirType
     mergingScript
-    inputs {{
+    inputs {
         ...entireInput
-    }}
-}}
+    }
+}
 
-query {{
-    resources(filter: {{
-        AND: {{
-            { f'''source: {{
-                name: {{ in: {selected_sources} }}
-            }}''' if selected_sources else ""}
-            { f"fhirType: {{ in: {selected_resources} }}" if selected_resources else ""}
-            { f"label: {{ in: {selected_labels} }}" if selected_labels else ""}
-        }}
-    }})
-    {{
+query {
+    resources(filter: {
+        AND: {
+            %s
+            %s
+            %s
+        }
+    })
+    {
         id
         fhirType
         primaryKeyOwner
         primaryKeyTable
         primaryKeyColumn
-        attributes {{
+        attributes {
             ...a
-            children {{
+            children {
                 ...a
-                children {{
+                children {
                     ...a
-                    children {{
+                    children {
                         ...a
-                        children {{
+                        children {
                             ...a
-                            children {{
+                            children {
                                 ...a
-                                children {{
+                                children {
                                     ...a
-                                    children {{
+                                    children {
                                         ...a
-                                        children {{
+                                        children {
                                             ...a
-                                            children {{
+                                            children {
                                                 ...a
-                                                children {{
+                                                children {
                                                     ...a
-                                                    children {{
+                                                    children {
                                                         ...a
-                                                        children {{
+                                                        children {
                                                             ...a
-                                                            children {{
+                                                            children {
                                                                 ...a
-                                                                children {{
+                                                                children {
                                                                     ...a
-                                                                }}
-                                                            }}
-                                                        }}
-                                                    }}
-                                                }}
-                                            }}
-                                        }}
-                                    }}
-                                }}
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        }}
-    }}
-}}
-""".replace(
-        "'", '"'
-    )
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+        % (source_filter, resource_filter, label_filter)
+    ).replace("'", '"')
 
 
 def get_headers():

--- a/fhirpipe/extract/graphql.py
+++ b/fhirpipe/extract/graphql.py
@@ -11,6 +11,7 @@ query {
         resources {
           id
           fhirType
+          label
         }
     }
 }

--- a/fhirpipe/extract/graphql.py
+++ b/fhirpipe/extract/graphql.py
@@ -3,111 +3,111 @@ import requests
 import fhirpipe
 
 
-sources_query = """
-query {
-    sources {
-        id
-        name
-        resources {
-          id
-          fhirType
-          label
-        }
-    }
-}
-"""
-
-resource_query = """
-fragment entireColumn on Column {
+def build_resources_query(selected_sources=None, selected_resources=None, selected_labels=None):
+    # NOTE the curly braces have to be doubled in f-strings
+    # NOTE The .replace("'", '"') is needed because the graphql needs to have
+    # strings delimited by double quotes
+    return f"""fragment entireColumn on Column {{
     id
     owner
     table
     column
-    joins {
+    joins {{
         id
-        tables {
+        tables {{
             id
             owner
             table
             column
-        }
-    }
-}
+        }}
+    }}
+}}
 
-fragment entireInput on Input {
+fragment entireInput on Input {{
     id
-    sqlValue {
+    sqlValue {{
         ...entireColumn
-    }
+    }}
     script
     staticValue
-}
+}}
 
-fragment a on Attribute {
+fragment a on Attribute {{
     id
     name
     fhirType
     mergingScript
-    inputs {
+    inputs {{
         ...entireInput
-    }
-}
+    }}
+}}
 
-query($resourceId: ID!) {
-    resource(resourceId: $resourceId) {
+query {{
+    resources(filter: {{
+        AND: {{
+            { f'''source: {{
+                name: {{ in: {selected_sources} }}
+            }}''' if selected_sources else ""}
+            { f"fhirType: {{ in: {selected_resources} }}" if selected_resources else ""}
+            { f"label: {{ in: {selected_labels} }}" if selected_labels else ""}
+        }}
+    }})
+    {{
         id
         fhirType
         primaryKeyOwner
         primaryKeyTable
         primaryKeyColumn
-        attributes {
+        attributes {{
             ...a
-            children {
+            children {{
                 ...a
-                children {
+                children {{
                     ...a
-                    children {
+                    children {{
                         ...a
-                        children {
+                        children {{
                             ...a
-                            children {
+                            children {{
                                 ...a
-                                children {
+                                children {{
                                     ...a
-                                    children {
+                                    children {{
                                         ...a
-                                        children {
+                                        children {{
                                             ...a
-                                            children {
+                                            children {{
                                                 ...a
-                                                children {
+                                                children {{
                                                     ...a
-                                                    children {
+                                                    children {{
                                                         ...a
-                                                        children {
+                                                        children {{
                                                             ...a
-                                                            children {
+                                                            children {{
                                                                 ...a
-                                                                children {
+                                                                children {{
                                                                     ...a
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-"""
+                                                                }}
+                                                            }}
+                                                        }}
+                                                    }}
+                                                }}
+                                            }}
+                                        }}
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+    }}
+}}
+""".replace(
+        "'", '"'
+    )
 
 
 def get_headers():

--- a/fhirpipe/utils.py
+++ b/fhirpipe/utils.py
@@ -1,7 +1,7 @@
 def build_col_name(table, column, owner=None):
     table = table.strip()
     column = column.strip()
-    owner = owner.strip()
+    owner = owner.strip() if owner is not None else owner
     if owner:
         return f"{owner}.{table}.{column}"
     else:

--- a/test/fixtures/mimic_mapping.json
+++ b/test/fixtures/mimic_mapping.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "ck5f5v2kd00023qmtzv2887fr",
-        "label": "",
+        "label": "pat_label",
         "profile": null,
         "fhirType": "Patient",
         "primaryKeyOwner": "",
@@ -7331,7 +7331,7 @@
     },
     {
         "id": "ck5ffy5ai08933qmtbzshjwfl",
-        "label": "",
+        "label": "service_label",
         "profile": null,
         "fhirType": "HealthcareService",
         "primaryKeyOwner": "",

--- a/test/fixtures/patient_pruned.json
+++ b/test/fixtures/patient_pruned.json
@@ -1,6 +1,6 @@
 {
   "id": "ck5f5v2kd00023qmtzv2887fr",
-  "label": "",
+  "label": "pat_label",
   "profile": null,
   "fhirType": "Patient",
   "primaryKeyOwner": "",

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -14,6 +14,7 @@ args = argparse.Namespace(
     multiprocessing=False,
     reset_store=True,
     resources=None,
+    labels=None,
     source=None,
     bypass_validation=False,
 )
@@ -51,6 +52,7 @@ args = argparse.Namespace(
     multiprocessing=False,
     reset_store=True,
     resources=["Patient", "not_existing_resource"],
+    labels=["pat_label"],
     source=None,
     bypass_validation=False,
 )
@@ -81,6 +83,7 @@ args = argparse.Namespace(
     multiprocessing=False,
     reset_store=True,
     resources=None,
+    labels=None,
     source=None,
     bypass_validation=False,
 )
@@ -103,6 +106,7 @@ args = argparse.Namespace(
     multiprocessing=True,
     reset_store=True,
     resources=None,
+    labels=None,
     source=None,
     bypass_validation=False,
 )
@@ -122,6 +126,7 @@ args1 = argparse.Namespace(
     multiprocessing=False,
     reset_store=True,
     resources=None,
+    labels=None,
     source=None,
     bypass_validation=False,
 )
@@ -133,6 +138,7 @@ args2 = argparse.Namespace(
     multiprocessing=False,
     reset_store=False,
     resources=None,
+    labels=None,
     source=None,
     bypass_validation=False,
 )

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -15,7 +15,7 @@ args = argparse.Namespace(
     reset_store=True,
     resources=None,
     labels=None,
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 
@@ -35,7 +35,7 @@ args = argparse.Namespace(
     multiprocessing=False,
     reset_store=True,
     resources=None,
-    source="mimic",
+    sources="mimic",
 )
 
 @mock.patch("fhirpipe.cli.run.parse_args", return_value=args)
@@ -53,7 +53,7 @@ args = argparse.Namespace(
     reset_store=True,
     resources=["Patient", "not_existing_resource"],
     labels=["pat_label"],
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 
@@ -84,7 +84,7 @@ args = argparse.Namespace(
     reset_store=True,
     resources=None,
     labels=None,
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 
@@ -107,7 +107,7 @@ args = argparse.Namespace(
     reset_store=True,
     resources=None,
     labels=None,
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 
@@ -127,7 +127,7 @@ args1 = argparse.Namespace(
     reset_store=True,
     resources=None,
     labels=None,
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 
@@ -139,7 +139,7 @@ args2 = argparse.Namespace(
     reset_store=False,
     resources=None,
     labels=None,
-    source=None,
+    sources=None,
     bypass_validation=False,
 )
 

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -14,4 +14,7 @@ def patient_pruned():
         return json.load(fp)
 
 
-mock_config = {"fhirstore": {"database": "fhirstore"}}
+mock_config = {
+    "fhirstore": {"database": "fhirstore"},
+    "graphql": {"token": "gql_token", "server": "gql_server"},
+}

--- a/test/unit/extract/test_graphql.py
+++ b/test/unit/extract/test_graphql.py
@@ -1,0 +1,80 @@
+from unittest import mock
+from pytest import raises
+
+from test.unit import mock_config
+import fhirpipe.extract.graphql as gql
+
+
+def test_build_resources_query():
+    # With selected sources
+    query = gql.build_resources_query(selected_sources=["mimic"])
+
+    assert (
+        """source: {
+                name: { in: ["mimic"] }
+            }"""
+        in query
+    )
+
+    # With selected resources
+    query = gql.build_resources_query(selected_resources=["Patient", "Observation"])
+
+    assert 'fhirType: { in: ["Patient", "Observation"] }' in query
+
+    # With selected sources
+    query = gql.build_resources_query(selected_labels=["label"])
+
+    assert 'label: { in: ["label"] }' in query
+
+    # With all arguments
+    query = gql.build_resources_query(
+        selected_sources=["mimic"],
+        selected_resources=["Patient", "Observation"],
+        selected_labels=["label"],
+    )
+
+    assert (
+        """source: {
+                name: { in: ["mimic"] }
+            }
+            fhirType: { in: ["Patient", "Observation"] }
+            label: { in: ["label"] }"""
+        in query
+    )
+
+
+@mock.patch("fhirpipe.extract.graphql.fhirpipe.global_config", mock_config)
+def test_get_headers():
+    header = gql.get_headers()
+
+    assert header == {
+        "content-type": "application/json",
+        "Authorization": "Bearer gql_token",
+    }
+
+
+@mock.patch("fhirpipe.extract.graphql.fhirpipe.global_config", mock_config)
+@mock.patch("fhirpipe.extract.graphql.requests.post")
+def test_run_graphql_query(mock_post):
+    mock_post.return_value = mock.MagicMock()
+
+    # No error
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"data": "successful query"}
+
+    response = gql.run_graphql_query("query")
+    assert response == {"data": "successful query"}
+
+    # Request error
+    mock_post.return_value.status_code = 400
+    mock_post.return_value.reason = "reason"
+
+    with raises(Exception, match=f"Query failed with returning code 400\nreason."):
+        gql.run_graphql_query("query")
+
+    # GraphQL error
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"data": None, "errors": "error message"}
+
+    with raises(Exception, match="GraphQL query failed with errors: error message."):
+        gql.run_graphql_query("query")

--- a/test/unit/extract/test_mapping.py
+++ b/test/unit/extract/test_mapping.py
@@ -1,10 +1,8 @@
-import os
 import json
 import pytest
 from unittest import mock, TestCase
 
 import fhirpipe.extract.mapping as mapping
-import fhirpipe.extract.graphql as gql
 
 from test.unit import exported_source, patient_pruned
 
@@ -23,20 +21,20 @@ def test_get_mapping(mock_get_mapping_from_graphql, mock_get_mapping_from_file):
     mock_get_mapping_from_file.reset_mock()
 
     # When providing source name
-    mapping.get_mapping(source_name="source", selected_resources=["sel"])
-    mock_get_mapping_from_graphql.assert_called_once_with("source", ["sel"], None)
+    mapping.get_mapping(selected_sources=["source"], selected_resources=["sel"])
+    mock_get_mapping_from_graphql.assert_called_once_with(["source"], ["sel"], None)
     mock_get_mapping_from_graphql.reset_mock()
 
-    mapping.get_mapping(source_name="source")
-    mock_get_mapping_from_graphql.assert_called_once_with("source", None, None)
+    mapping.get_mapping(selected_sources=["source"])
+    mock_get_mapping_from_graphql.assert_called_once_with(["source"], None, None)
     mock_get_mapping_from_graphql.reset_mock()
 
     # When providing both
-    mapping.get_mapping(from_file="file", source_name="source", selected_resources=["sel"])
+    mapping.get_mapping(from_file="file", selected_sources=["source"], selected_resources=["sel"])
     mock_get_mapping_from_file.assert_called_once_with("file", ["sel"], None)
     mock_get_mapping_from_file.reset_mock()
 
-    mapping.get_mapping(from_file="file", source_name="source")
+    mapping.get_mapping(from_file="file", selected_sources=["source"])
     mock_get_mapping_from_file.assert_called_once_with("file", None, None)
     mock_get_mapping_from_file.reset_mock()
 
@@ -110,60 +108,24 @@ def test_get_mapping_from_file(exported_source):
 
 
 def mock_run_graphql_query(graphql_query, variables=None):
-    if graphql_query == gql.sources_query:
-        return {
-            "data": {
-                "sources": [
-                    {
-                        "id": 123,
-                        "name": "aphp",
-                        "resources": [
-                            {"id": 1, "label": "pat_label", "fhirType": "Patient"},
-                            {"id": 2, "label": "obs_label", "fhirType": "Observation"},
-                        ],
-                    },
-                    {
-                        "id": 456,
-                        "name": "chimio",
-                        "resources": [
-                            {"id": 3, "label": "pract_label", "fhirType": "Practitioner"},
-                            {"id": 4, "label": "med_label", "fhirType": "Medication"},
-                        ],
-                    },
-                ]
-            }
-        }
-
-    elif graphql_query == gql.resource_query:
-
-        if variables["resourceId"] == 1:
-            return {"data": {"resource": {"id": 1, "content": "content1"}}}
-
-        elif variables["resourceId"] == 2:
-            return {"data": {"resource": {"id": 2, "content": "content2"}}}
+    return {
+        "data": {"resources": [{"id": 1, "content": "content1"}, {"id": 2, "content": "content2"}]}
+    }
 
 
 @mock.patch("fhirpipe.extract.mapping.run_graphql_query", mock_run_graphql_query)
-def test_get_mapping_from_graphql():
-    # With selected resources
-    resources = mapping.get_mapping_from_graphql("aphp", ["Patient"], None)
+@mock.patch("fhirpipe.extract.mapping.build_resources_query")
+def test_get_mapping_from_graphql(mock_build_resources_query):
+    resources = mapping.get_mapping_from_graphql(["chimio"], ["Patient"], None)
+    # Need to consume the generator for the assert_called_once_with to work
+    resources = list(resources)
 
-    assert list(resources) == [{"id": 1, "content": "content1"}]
+    mock_build_resources_query.assert_called_once_with(["chimio"], ["Patient"], None)
 
-    # Without selected resources
-    resources = mapping.get_mapping_from_graphql("aphp", None, None)
-
-    assert list(resources) == [
+    assert resources == [
         {"id": 1, "content": "content1"},
         {"id": 2, "content": "content2"},
     ]
-
-    # With selected label
-    resources = mapping.get_mapping_from_graphql("aphp", ["Patient"], ["wrong_label"])
-    assert list(resources) == []
-
-    resources = mapping.get_mapping_from_graphql("aphp", ["Patient"], ["pat_label"])
-    assert list(resources) == [{"id": 1, "content": "content1"}]
 
 
 def test_prune_fhir_resource(exported_source, patient_pruned):

--- a/test/unit/extract/test_sql.py
+++ b/test/unit/extract/test_sql.py
@@ -1,6 +1,3 @@
-from unittest import mock
-
-import fhirpipe
 import fhirpipe.extract.sql as sql
 
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,25 @@
+import fhirpipe.utils as utils
+
+
+def test_build_col_name():
+    result = utils.build_col_name("table", "col", "owner")
+    assert result == "owner.table.col"
+
+    result = utils.build_col_name("table", "col")
+    assert result == "table.col"
+
+
+def test_new_col_name():
+    result = utils.new_col_name("clean", "col")
+    assert result == "clean_col"
+
+    result = utils.new_col_name("merge", (["col1", "col2"], ["static1", "static2"]))
+    assert result == "merge_col1_col2_static1_static2"
+
+
+def test_get_table_name():
+    result = utils.get_table_name("owner.table.col")
+    assert result == "owner.table"
+
+    result = utils.get_table_name("table.col")
+    assert result == "table"


### PR DESCRIPTION
Add an argument to be more precise when selecting resources to transform.

Before, when we had several resources of the same type in the mapping (several Patient for instance), we had no way of launching the pipe only for one of them.

I also added a few unit tests to improve coverage.