### PR TITLE
Modify reference paths parsing

### DIFF
--- a/fhirpipe/analyze/analysis.py
+++ b/fhirpipe/analyze/analysis.py
@@ -12,7 +12,7 @@ class Analysis:
         self.joins: Set[SqlJoin] = set()
         self.primary_key_column: SqlColumn = None
         self.squash_rules = None
-        self.reference_paths: List[str] = []
+        self.reference_paths: Set[str] = set()
 
     def reset(self):
         self.attributes = []
@@ -20,7 +20,7 @@ class Analysis:
         self.joins = set()
         self.primary_key_column = None
         self.squash_rules = None
-        self.reference_paths = []
+        self.reference_paths = set()
 
     def add_column(self, column):
         self.columns.add(column)

--- a/fhirpipe/analyze/analyzer.py
+++ b/fhirpipe/analyze/analyzer.py
@@ -1,3 +1,5 @@
+import re
+
 from .mapping import build_squash_rules
 from .analysis import Analysis
 from .attribute import Attribute
@@ -46,7 +48,9 @@ class Analyzer:
             # attribute (ie not a leaf). It is here to give us some context information.
             # For instance, we can use it if its children attributes represent a Reference.
             if attribute_mapping["definitionId"] == "Reference":
-                self.analysis.reference_paths.append(attribute.path)
+                # Remove index
+                path = re.sub(r"\[\d+\]$", "", attribute.path)
+                self.analysis.reference_paths.add(path)
 
             return
 

--- a/test/fixtures/mimic_mapping.json
+++ b/test/fixtures/mimic_mapping.json
@@ -570,7 +570,7 @@
                 },
                 {
                     "id": "ck7ugxjzt01846kz9fi3rchdv",
-                    "path": "generalPractitioner",
+                    "path": "generalPractitioner[0]",
                     "definitionId": "Reference",
                     "mergingScript": null,
                     "comments": null,

--- a/test/fixtures/patient_mapping.json
+++ b/test/fixtures/patient_mapping.json
@@ -85,7 +85,7 @@
       },
       {
           "id": "ck7ugxjzt01846kz9fi3rchdv",
-          "path": "generalPractitioner",
+          "path": "generalPractitioner[0]",
           "definitionId": "Reference",
           "mergingScript": null,
           "comments": null,


### PR DESCRIPTION
This PR follows this one on Pyrog: https://github.com/arkhn/pyrog/pull/204.

Now that paths for array attributes have changed, we need to change the way to parse and store reference paths.