### PR TITLE
Manual column labelling and fix fhir object building

### DIFF
--- a/fhirpipe/extract/extractor.py
+++ b/fhirpipe/extract/extractor.py
@@ -148,7 +148,7 @@ class Extractor:
             the result of the sql query run on the specified connection type
                 or an iterator if chunksize is specified
         """
-        query = query.with_labels().statement
+        query = query.statement
         logging.info(f"sql query: {query}")
 
         pd_query = pd.read_sql_query(query, con=self.engine, chunksize=chunksize)
@@ -173,7 +173,9 @@ class Extractor:
         from the analysis.
         """
         table = self.get_table(column)
-        return table.c[column.column]
+        # Note that we label the column manually to avoid collisions and
+        # sqlAlchemy automatic labelling
+        return table.c[column.column].label(column.dataframe_column_name())
 
     def get_table(self, column: SqlColumn) -> Table:
         """ Get the sql alchemy table corresponding to the SqlColumn (custom type)

--- a/fhirpipe/load/loader.py
+++ b/fhirpipe/load/loader.py
@@ -1,14 +1,12 @@
-from functools import partial
 import logging
 
 from fhirpipe.load.fhirstore import save_many
 
 
 class Loader:
-    def __init__(self, fhirstore, bypass_validation, pool=None):
+    def __init__(self, fhirstore, bypass_validation):
         self.fhirstore = fhirstore
         self.bypass_validation = bypass_validation
-        self.pool = pool
 
     def load(self, fhirstore, fhir_instances, resource_type):
         logging.info("Loading resource: %s", resource_type)
@@ -17,10 +15,4 @@ class Loader:
         if resource_type not in self.fhirstore.resources:
             self.fhirstore.bootstrap(resource=resource_type, depth=3)
 
-        if self.pool:
-            self.pool.map(
-                partial(save_many, bypass_validation=self.bypass_validation, multi_processing=True),
-                fhir_instances,
-            )
-        else:
-            save_many(fhir_instances, self.bypass_validation)
+        save_many(fhir_instances, self.bypass_validation)

--- a/fhirpipe/run.py
+++ b/fhirpipe/run.py
@@ -46,7 +46,7 @@ def run(
     analyzer = Analyzer()
     extractor = Extractor(credentials, chunksize)
     transformer = Transformer(pool)
-    loader = Loader(fhirstore, bypass_validation, pool)
+    loader = Loader(fhirstore, bypass_validation)
 
     # TODO is there a more elegant way to skip_ref_binding?
     binder = ReferenceBinder(fhirstore, skip_ref_binding, bypass_validation)

--- a/fhirpipe/run.py
+++ b/fhirpipe/run.py
@@ -75,12 +75,7 @@ def run(
             # Transform
             fhir_instances = transformer.transform(chunk, resource_mapping, analysis)
             # Load
-            if not multiprocessing:
-                # With multiprocessing, the transformer returns a list of lists of fhir_instances
-                # (one list per process)
-                fhir_instances = [fhir_instances]
-            for chunk in fhir_instances:
-                loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
+            loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
 
     binder.bind_references()
 

--- a/fhirpipe/run.py
+++ b/fhirpipe/run.py
@@ -75,7 +75,12 @@ def run(
             # Transform
             fhir_instances = transformer.transform(chunk, resource_mapping, analysis)
             # Load
-            loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
+            if not multiprocessing:
+                # With multiprocessing, the transformer returns a list of lists of fhir_instances
+                # (one list per process)
+                fhir_instances = [fhir_instances]
+            for chunk in fhir_instances:
+                loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
 
     binder.bind_references()
 

--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -79,6 +79,13 @@ def build_fhir_object(row, path_attributes_map, index=None):
             # is not a leaf and we don't need to do anything.
             continue
 
+        # Handle the list of literals case.
+        # If we had a list of literals in the mapping, then handle_array_attributes
+        # will try to create fhir objects with an empty path (remove_root_path removes
+        # what's before the [...] included).
+        if path == "":
+            return fetch_values_from_dataframe(row, attr)
+
         # Find if there is an index in the path
         split_path = path.split(".")
         position_ind = get_position_first_index(split_path)
@@ -154,7 +161,7 @@ def handle_array_attributes(attributes_in_array, row):
     array = []
     for index in range(length):
         element = build_fhir_object(row, attributes_in_array, index=index)
-        if element is not None:
+        if element is not None and element != {}:
             array.append(element)
 
     return array
@@ -173,7 +180,7 @@ def insert_in_fhir_object(fhir_object, path, value):
     # TODO we return if value is "" because empty strings don't pass validation for some fhir
     # attributes but it would be better to return None in the cleaning scripts if we don't want to
     # add an empty string.
-    elif value is None or value == "":
+    elif value is None or value == "" or value == {}:
         # If value is None, we don't want to do anything so we stop here.
         return
     else:

--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -12,8 +12,7 @@ def recursive_defaultdict():
     return defaultdict(recursive_defaultdict)
 
 
-def create_resource(chunk, resource_mapping, attributes):
-    res = []
+def create_resource(chunk, resource_mapping, attributes, res):
     for _, row in chunk.iterrows():
         try:
             res.append(create_instance(row, resource_mapping, attributes))
@@ -22,8 +21,6 @@ def create_resource(chunk, resource_mapping, attributes):
             # and we try to generate the next one
             logging.error(f"create_instance failed with: {e}")
             continue
-
-    return res
 
 
 def create_instance(row, resource_mapping, attributes):

--- a/test/unit/transform/test_fhir.py
+++ b/test/unit/transform/test_fhir.py
@@ -77,7 +77,8 @@ def test_create_resource(mock_datetime, patient_mapping, fhir_concept_map_identi
     )
     resource_mapping = patient_mapping
 
-    actual = transform.create_resource(rows, resource_mapping, attributes)
+    actual = []
+    transform.create_resource(rows, resource_mapping, attributes, actual)
 
     assert actual == [
         {


### PR DESCRIPTION
- Label query columns manually to avoid collisions and sqlAlchemy labelling
- Remove empty objects from fhir object
- Put back handling of array of literals
- Also closes #93 