### PR TITLE
Enable static resource creation

### DIFF
--- a/fhirpipe/analyze/analysis.py
+++ b/fhirpipe/analyze/analysis.py
@@ -13,6 +13,7 @@ class Analysis:
         self.primary_key_column: SqlColumn = None
         self.squash_rules = None
         self.reference_paths: Set[str] = set()
+        self.is_static = False
 
     def reset(self):
         self.attributes = []
@@ -21,6 +22,7 @@ class Analysis:
         self.primary_key_column = None
         self.squash_rules = None
         self.reference_paths = set()
+        self.is_static = False
 
     def add_column(self, column):
         self.columns.add(column)

--- a/fhirpipe/analyze/analyzer.py
+++ b/fhirpipe/analyze/analyzer.py
@@ -17,21 +17,24 @@ class Analyzer:
     def analyze(self, resource_mapping):
         self.analysis.reset()
 
-        # Get primary key table
-        self.get_primary_key(resource_mapping)
-
         # Analyze the mapping
         self.analyze_mapping(resource_mapping)
 
-        # Add primary key to columns to fetch if needed
-        self.analysis.add_column(self.analysis.primary_key_column)
+        if not self.analysis.columns:
+            self.analysis.is_static = True
+        else:
+            # Get primary key table
+            self.get_primary_key(resource_mapping)
 
-        # Build squash rules
-        self.analysis.squash_rules = build_squash_rules(
-            self.analysis.columns,
-            self.analysis.joins,
-            self.analysis.primary_key_column.table_name(),
-        )
+            # Add primary key to columns to fetch if needed
+            self.analysis.add_column(self.analysis.primary_key_column)
+
+            # Build squash rules
+            self.analysis.squash_rules = build_squash_rules(
+                self.analysis.columns,
+                self.analysis.joins,
+                self.analysis.primary_key_column.table_name(),
+            )
 
         return self.analysis
 

--- a/fhirpipe/api/routes.py
+++ b/fhirpipe/api/routes.py
@@ -54,8 +54,6 @@ def preview(resource_id, primary_key_value):
     resource_mapping = get_resource_from_id(resource_id)
 
     # Get credentials if given in request
-    credentials = None
-
     if not resource_mapping["source"]["credential"]:
         raise OperationOutcome("credentialId is required to run fhirpipe.")
 

--- a/fhirpipe/run.py
+++ b/fhirpipe/run.py
@@ -74,17 +74,16 @@ def run(
             fhir_instance = transformer.transform_static_resource(resource_mapping, analysis)
             # Load
             loader.load(fhirstore, [fhir_instance], resource_mapping["definition"]["type"])
-            # Process next resource
-            continue
 
-        # Extract
-        df = extractor.extract(resource_mapping, analysis)
+        else:
+            # Extract
+            df = extractor.extract(resource_mapping, analysis)
 
-        for chunk in df:
-            # Transform
-            fhir_instances = transformer.transform(chunk, resource_mapping, analysis)
-            # Load
-            loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
+            for chunk in df:
+                # Transform
+                fhir_instances = transformer.transform(chunk, resource_mapping, analysis)
+                # Load
+                loader.load(fhirstore, fhir_instances, resource_mapping["definition"]["type"])
 
     binder.bind_references()
 

--- a/fhirpipe/transform/fhir.py
+++ b/fhirpipe/transform/fhir.py
@@ -12,6 +12,14 @@ def recursive_defaultdict():
     return defaultdict(recursive_defaultdict)
 
 
+def create_static_instance(resource_mapping, attributes):
+    try:
+        return create_instance({}, resource_mapping, attributes)
+    except Exception as e:
+        # If cannot build the fhir object, a warning has been logged
+        logging.error(f"create_static_instance failed with: {e}")
+
+
 def create_resource(chunk, resource_mapping, attributes, res):
     for _, row in chunk.iterrows():
         try:

--- a/fhirpipe/transform/transformer.py
+++ b/fhirpipe/transform/transformer.py
@@ -4,7 +4,7 @@ from functools import partial
 import logging
 
 from fhirpipe.transform.dataframe import clean_dataframe, squash_rows, merge_dataframe
-from fhirpipe.transform.fhir import create_resource
+from fhirpipe.transform.fhir import create_resource, create_static_instance
 
 
 class Transformer:
@@ -43,3 +43,6 @@ class Transformer:
             create_resource(chunk, resource_mapping, analysis.attributes, fhir_instances)
 
         return fhir_instances
+
+    def transform_static_resource(self, resource_mapping, analysis):
+        return create_static_instance(resource_mapping, analysis.attributes)

--- a/test/fixtures/mimic_mapping.json
+++ b/test/fixtures/mimic_mapping.json
@@ -1777,9 +1777,9 @@
             "id": "static_id",
             "label": "pat_label",
             "primaryKeyOwner": null,
-            "primaryKeyTable": "patients",
+            "primaryKeyTable": null,
             "primaryKeyColumn": null,
-            "definitionId": null,
+            "definitionId": "PractitionerRole",
             "updatedAt": "2020-03-16T11:23:04.247Z",
             "createdAt": "2020-03-16T11:23:04.247Z",
             "source": {

--- a/test/fixtures/mimic_mapping.json
+++ b/test/fixtures/mimic_mapping.json
@@ -1772,6 +1772,78 @@
                     }
                 ]
             }
+        },
+        {
+            "id": "static_id",
+            "label": "pat_label",
+            "primaryKeyOwner": null,
+            "primaryKeyTable": "patients",
+            "primaryKeyColumn": null,
+            "definitionId": null,
+            "updatedAt": "2020-03-16T11:23:04.247Z",
+            "createdAt": "2020-03-16T11:23:04.247Z",
+            "source": {
+                "id": "mimicSourceId",
+                "name": "mimic",
+                "version": null,
+                "hasOwner": false,
+                "updatedAt": "2020-03-16T11:23:04.159Z",
+                "createdAt": "2020-03-16T11:23:04.159Z"
+            },
+            "filters": [],
+            "attributes": [
+                {
+                    "id": "ck7udsj7s01386kz9bm0n8xua",
+                    "path": "identifier[0].value",
+                    "definitionId": "string",
+                    "mergingScript": null,
+                    "comments": null,
+                    "updatedAt": "2020-03-16T11:25:09.825Z",
+                    "createdAt": "2020-03-16T11:25:09.825Z",
+                    "inputs": [
+                        {
+                            "id": "ck7udsjcw01406kz9g8hxsow5",
+                            "script": null,
+                            "conceptMapId": null,
+                            "staticValue": "static_id_value",
+                            "updatedAt": "2020-03-16T11:25:09.974Z",
+                            "createdAt": "2020-03-16T11:25:09.974Z",
+                            "sqlValue": null
+                        }
+                    ]
+                },
+                {
+                    "id": "ck7ufgp5f01466kz9rpvqmd8w",
+                    "path": "identifier[0].system",
+                    "definitionId": "CodeableConcept",
+                    "mergingScript": null,
+                    "comments": null,
+                    "updatedAt": "2020-03-16T12:11:56.873Z",
+                    "createdAt": "2020-03-16T12:11:56.873Z",
+                    "inputs": [
+                      {
+                          "id": "ck7udsjcw01406kz9g8hxsow5",
+                          "script": null,
+                          "conceptMapId": null,
+                          "staticValue": "static_id_system",
+                          "updatedAt": "2020-03-16T11:25:09.974Z",
+                          "createdAt": "2020-03-16T11:25:09.974Z",
+                          "sqlValue": null
+                      }
+                  ]
+                }
+            ],
+            "definition": {
+                "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+                "derivation": "specialization",
+                "id": "PractitionerRole",
+                "kind": "resource",
+                "name": "PractitionerRole",
+                "publisher": "Health Level Seven International (Patient Administration)",
+                "type": "PractitionerRole",
+                "min": 0,
+                "max": "*"
+            }
         }
     ],
     "version": 5

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -183,6 +183,7 @@ def assert_result_as_expected(
             "MedicationRequest",
             "DiagnosticReport",
             "Practitioner",
+            "PractitionerRole",
         ],
     )
     assert_document_counts(
@@ -196,6 +197,7 @@ def assert_result_as_expected(
 
     compare_sample_patient(mongo_client)
     compare_sample_med_req(mongo_client)
+    compare_practitioner_role(mongo_client)
 
 
 def assert_document_counts(
@@ -211,6 +213,7 @@ def assert_document_counts(
     assert mongo_client["MedicationRequest"].count_documents({}) == medication_request_count
     assert mongo_client["DiagnosticReport"].count_documents({}) == diagnostic_report_count
     assert mongo_client["Practitioner"].count_documents({}) == admissions_count
+    assert mongo_client["PractitionerRole"].count_documents({}) == 1
 
 
 def compare_sample_patient(mongo_client):
@@ -317,5 +320,23 @@ def compare_sample_med_req(mongo_client):
                 "code": "mL",
                 "system": "https://unitsofmeasure.org/",
             },
+        },
+    }
+
+
+def compare_practitioner_role(mongo_client):
+    practitioner_role = mongo_client["PractitionerRole"].find_one({})
+
+    assert practitioner_role == {
+        "_id": practitioner_role["_id"],
+        "id": practitioner_role["id"],
+        "identifier": [{"value": "static_id_value", "system": "static_id_system"}],
+        "resourceType": "PractitionerRole",
+        "meta": {
+            "lastUpdated": lastUpdated,
+            "tag": [
+                {"system": ARKHN_CODE_SYSTEMS.source, "code": "mimicSourceId"},
+                {"system": ARKHN_CODE_SYSTEMS.resource, "code": "static_id"},
+            ],
         },
     }

--- a/test/unit/analyze/test_mapping.py
+++ b/test/unit/analyze/test_mapping.py
@@ -42,6 +42,7 @@ def test_get_mapping_from_file(exported_source):
             "EpisodeOfCare",
             "DiagnosticReport",
             "MedicationRequest",
+            "PractitionerRole",
         ],
     )
     TestCase().assertCountEqual(

--- a/test/unit/transform/test_fhir.py
+++ b/test/unit/transform/test_fhir.py
@@ -15,6 +15,43 @@ class mockdatetime:
 
 
 @mock.patch("fhirpipe.transform.fhir.datetime", autospec=True)
+def test_create_static_instance(mock_datetime, fhir_concept_map_identifier):
+    mock_datetime.now.return_value = mockdatetime()
+
+    resource_mapping = {
+        "id": "resource_id",
+        "source": {"id": "source_id"},
+        "definition": {"type": "instance_type", "kind": "resource", "derivation": "resource"},
+    }
+
+    attr_identifier_val = Attribute("identifier[0].value", static_inputs=["static"])
+    attr_identifier_sys = Attribute("identifier[0].system", static_inputs=["identifier_sys"])
+    attr_val = Attribute("path.to.attribute", static_inputs=["attribute_val"])
+
+    attributes = [attr_identifier_val, attr_identifier_sys, attr_val]
+
+    actual = transform.create_static_instance(resource_mapping, attributes)
+
+    assert actual == {
+        "meta": {
+            "lastUpdated": "now",
+            "tag": [
+                {"system": ARKHN_CODE_SYSTEMS.source, "code": resource_mapping["source"]["id"]},
+                {"system": ARKHN_CODE_SYSTEMS.resource, "code": resource_mapping["id"]},
+            ],
+        },
+        "id": actual["id"],
+        "identifier": [{"value": "static", "system": "identifier_sys"}],
+        "path": {
+            "to": {
+                "attribute": "attribute_val",
+            }
+        },
+        "resourceType": "instance_type",
+    }
+
+
+@mock.patch("fhirpipe.transform.fhir.datetime", autospec=True)
 def test_create_instance(mock_datetime, patient_mapping, fhir_concept_map_identifier):
     mock_datetime.now.return_value = mockdatetime()
 


### PR DESCRIPTION
Maybe not a long-term solution but this enables the creation of static resources.

A static resource instance will be created no sql input is provided in the mapping. In this case, no need for a primary key.