### PR TITLE
Remove cleaning scripts version from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cleaning-scripts==0.2.12
+cleaning-scripts
 cx_Oracle==7.1.2
 fhirstore==0.3.9
 Flask-Cors==3.0.8


### PR DESCRIPTION
This PR removes the version number of the cleaning-scripts package in `requirements.txt` to avoid changing it everytime the cleaning-scripts package is updated.